### PR TITLE
Add modlog monitoring

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,9 +6,11 @@ flag_dv="TRUE"
 flag_pm="TRUE"
 flag_reports="TRUE"
 notify_new="FALSE"
+get_modlog="FALSE" # set to true after we've checked the modbots are subbed to the right communities
+modlog_pm="FALSE"  # set to true after one execution
 
 gc_deploy() {
-  gcloud run jobs deploy modreportbot-$1 --project=$project --region=$region --source . --set-env-vars=LEMMY_USER="fnicmodbot",LEMMY_INSTANCE="$2",MATRIX_USER="@fnic_reports:matrix.org",MATRIX_SERVER="matrix.org",MATRIX_ROOM="$matrix_room",FLAG_DOWNVOTES="$flag_dv",GET_MESSAGES="$flag_pm",GET_REPORTS="$flag_reports",NOTIFY_NEW="$notify_new" --set-secrets="LEMMY_PW=fnicmodbot-$1:latest","MATRIX_PW=fnicreports:latest" &
+  gcloud run jobs deploy modreportbot-$1 --project=$project --region=$region --source . --set-env-vars=LEMMY_USER="fnicmodbot",LEMMY_INSTANCE="$2",MATRIX_USER="@fnic_reports:matrix.org",MATRIX_SERVER="matrix.org",MATRIX_ROOM="$matrix_room",FLAG_DOWNVOTES="$flag_dv",GET_MESSAGES="$flag_pm",GET_REPORTS="$flag_reports",NOTIFY_NEW="$notify_new",GET_MODLOG="$get_modlog",MODLOG_PM="$modlog_pm" --set-secrets="LEMMY_PW=fnicmodbot-$1:latest","MATRIX_PW=fnicreports:latest" &
 }
 
 gc_deploy "lemmings-world" "lemmings.world"
@@ -16,7 +18,7 @@ gc_deploy "dbzer0" "lemmy.dbzer0.com"
 gc_deploy "lemm-ee" "lemm.ee"
 gc_deploy "lemmy-world" "lemmy.world"
 
-gcloud run jobs deploy modreportbot-directorybot --project=$project --region=$region --source . --set-env-vars=LEMMY_USER="directorybot",LEMMY_INSTANCE="lemmy.dbzer0.com",MATRIX_USER="@fnic_reports:matrix.org",MATRIX_SERVER="matrix.org",MATRIX_ROOM="$matrix_room",FLAG_DOWNVOTES="FALSE",GET_MESSAGES="TRUE",GET_REPORTS="FALSE",NOTIFY_NEW="TRUE" --set-secrets="LEMMY_PW=directorybot:latest","MATRIX_PW=fnicreports:latest" &
+gcloud run jobs deploy modreportbot-directorybot --project=$project --region=$region --source . --set-env-vars=LEMMY_USER="directorybot",LEMMY_INSTANCE="lemmy.dbzer0.com",MATRIX_USER="@fnic_reports:matrix.org",MATRIX_SERVER="matrix.org",MATRIX_ROOM="$matrix_room",FLAG_DOWNVOTES="FALSE",GET_MESSAGES="TRUE",GET_REPORTS="FALSE",NOTIFY_NEW="TRUE",GET_MODLOG="FALSE",MODLOG_PM="FALSE" --set-secrets="LEMMY_PW=directorybot:latest","MATRIX_PW=fnicreports:latest" &
 
 wait
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,8 +6,8 @@ flag_dv="TRUE"
 flag_pm="TRUE"
 flag_reports="TRUE"
 notify_new="FALSE"
-get_modlog="FALSE" # set to true after we've checked the modbots are subbed to the right communities
-modlog_pm="FALSE"  # set to true after one execution
+get_modlog="TRUE"
+modlog_pm="TRUE"
 
 gc_deploy() {
   gcloud run jobs deploy modreportbot-$1 --project=$project --region=$region --source . --set-env-vars=LEMMY_USER="fnicmodbot",LEMMY_INSTANCE="$2",MATRIX_USER="@fnic_reports:matrix.org",MATRIX_SERVER="matrix.org",MATRIX_ROOM="$matrix_room",FLAG_DOWNVOTES="$flag_dv",GET_MESSAGES="$flag_pm",GET_REPORTS="$flag_reports",NOTIFY_NEW="$notify_new",GET_MODLOG="$get_modlog",MODLOG_PM="$modlog_pm" --set-secrets="LEMMY_PW=fnicmodbot-$1:latest","MATRIX_PW=fnicreports:latest" &
@@ -21,4 +21,3 @@ gc_deploy "lemmy-world" "lemmy.world"
 gcloud run jobs deploy modreportbot-directorybot --project=$project --region=$region --source . --set-env-vars=LEMMY_USER="directorybot",LEMMY_INSTANCE="lemmy.dbzer0.com",MATRIX_USER="@fnic_reports:matrix.org",MATRIX_SERVER="matrix.org",MATRIX_ROOM="$matrix_room",FLAG_DOWNVOTES="FALSE",GET_MESSAGES="TRUE",GET_REPORTS="FALSE",NOTIFY_NEW="TRUE",GET_MODLOG="FALSE",MODLOG_PM="FALSE" --set-secrets="LEMMY_PW=directorybot:latest","MATRIX_PW=fnicreports:latest" &
 
 wait
-

--- a/main.py
+++ b/main.py
@@ -17,16 +17,18 @@ DOWNVOTES = os.getenv("FLAG_DOWNVOTES", 0)
 PRIVATEMESSAGES = os.getenv("GET_MESSAGES", 0)
 MODREPORTS = os.getenv("GET_REPORTS", 0)
 NEWPOSTS = os.getenv("NOTIFY_NEW", 0)
+MODLOG = os.getenv("GET_MODLOG", 0)
+MODLOG_PM = os.getenv("MODLOG_PM", 0)
 
-def main(user, pw, inst, room, muser, mpw, mserver, dv, pm, reports, newposts):
+def main(user, pw, inst, room, muser, mpw, mserver, dv, pm, reports, newposts, modlog, modlog_pm):
 
-    modreport.run(user, pw, inst, room, muser, mpw, mserver, dv, pm, reports, newposts, True)
+    modreport.run(user, pw, inst, room, muser, mpw, mserver, dv, pm, reports, newposts, modlog, modlog_pm, True)
     return "modreportbot"
 
 # Start script
 if __name__ == "__main__":
     try:
-        main(BOTUSER, BOTPW, BOTINSTANCE, MATRIXROOM, MATRIXUSER, MATRIXPW, MATRIXSERVER, DOWNVOTES, PRIVATEMESSAGES, MODREPORTS, NEWPOSTS)
+        main(BOTUSER, BOTPW, BOTINSTANCE, MATRIXROOM, MATRIXUSER, MATRIXPW, MATRIXSERVER, DOWNVOTES, PRIVATEMESSAGES, MODREPORTS, NEWPOSTS, MODLOG, MODLOG_PM)
     except Exception as err:
         message = (
             f"Task #{TASK_INDEX}, " + f"Attempt #{TASK_ATTEMPT} failed: {str(err)}"

--- a/modlog.py
+++ b/modlog.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python3
+import json
+import matrix
+import firestore
+
+from pythorhead import Lemmy
+from pythorhead.types import ModlogActionType,ListingType
+
+def run(lemmy, l_user, l_inst, live, room, muser, mpw, mserver, pm_modlogs):
+  processed_modlogs = {}
+  processed_modlogs['removed_posts'] = []
+  doc = f'{l_user}.{l_inst}'
+  if live:
+    processed_modlogs = firestore.get("modlogs", doc)
+  if processed_modlogs is None:
+    processed_modlogs = {}
+  if 'removed_posts' not in processed_modlogs:
+    processed_modlogs['removed_posts'] = []
+
+  # get list of subscribed commmunities
+  # NB: this should really be moderated communities
+  #     but a bug prevents that from working correctly
+  commlist = []
+  cl = lemmy.community.list(type_=ListingType.Subscribed)
+  n = 1
+  while len(cl)>0:
+    for cc in cl:
+      commlist.append(cc['community']['id'])
+    n+=1
+    cl = lemmy.community.list(type_=ListingType.Subscribed, page=n)
+
+  # Get the modlog for each community
+  for c in commlist:
+    ml = lemmy.modlog.get(community_id=c,type_=ModlogActionType.ModRemovePost,limit=4)
+
+    ppid = 0
+
+    for log in ml['removed_posts']:
+      if ppid == log['mod_remove_post']['post_id']:
+        continue # skip duplicates
+      ppid = log['mod_remove_post']['post_id']
+
+      if log['mod_remove_post']['id'] in processed_modlogs['removed_posts']:
+        break # stop processing if we've already seen a log as they are in descending order
+
+      if "reason" in log['mod_remove_post']:
+        reason = log['mod_remove_post']['reason']
+      else:
+        reason = "None given"
+      msg = f"\"{log['post']['name']}\" in \"{log['community']['name']}\" has been removed due to reason: {reason}"
+      print(f"{log['mod_remove_post']['id']} {msg}")
+      user=lemmy.user.get(person_id=log['post']['creator_id']) # look up user
+      if 'display_name' in user['person_view']['person']:
+        msg_to = user['person_view']['person']['display_name']
+      else:
+        msg_to = user['person_view']['person']['name']
+
+      if live:
+        processed_modlogs['removed_posts'].append(log['mod_remove_post']['id'])
+        # Post to Matrix
+        matrix.post(f'[modlog] {msg}', room, muser, mpw, mserver)
+        # Send PM to the poster
+        if pm_modlogs is True:
+          pm_msg = f"Dear {msg_to},\n\nYour post {msg}\n\nIf you are able to correct this please feel free to re-post."
+          lemmy.private_message.create(recipient_id=log['post']['creator_id'],content=pm_msg)
+
+  if live:
+    firestore.set("modlogs", doc, processed_modlogs)

--- a/modreport.py
+++ b/modreport.py
@@ -10,7 +10,7 @@ import privatemsg
 import newposts
 from pythorhead import Lemmy
 
-def run(user, pw, instance, room, muser, mpw, mserver, dv, pm, reports, np, live):
+def run(user, pw, instance, room, muser, mpw, mserver, dv, pm, reports, np, ml, ml_pm, live):
   posted_reports = { }
   posted_reports["posts"] = []
   posted_reports["comments"] = []
@@ -41,6 +41,11 @@ def run(user, pw, instance, room, muser, mpw, mserver, dv, pm, reports, np, live
 
   if pm == "TRUE":
     privatemsg.run(lemmy, live, room, muser, mpw, mserver)
+
+  if ml == "TRUE":
+    if ml_pm == "TRUE":
+      pm_modlogs = True
+    modlog.run(lemmy, user, instance, live, room, muser, mpw, mserver, pm_modlogs)
 
   if reports != "TRUE":
     # not getting reports so nothing more to do

--- a/modreport.py
+++ b/modreport.py
@@ -8,6 +8,7 @@ import matrix
 import downvotes
 import privatemsg
 import newposts
+import modlog
 from pythorhead import Lemmy
 
 def run(user, pw, instance, room, muser, mpw, mserver, dv, pm, reports, np, ml, ml_pm, live):

--- a/modreport.py
+++ b/modreport.py
@@ -46,7 +46,7 @@ def run(user, pw, instance, room, muser, mpw, mserver, dv, pm, reports, np, ml, 
   if ml == "TRUE":
     if ml_pm == "TRUE":
       pm_modlogs = True
-    else
+    else:
       pm_modlogs = False
     modlog.run(lemmy, user, instance, live, room, muser, mpw, mserver, pm_modlogs)
 

--- a/modreport.py
+++ b/modreport.py
@@ -46,6 +46,8 @@ def run(user, pw, instance, room, muser, mpw, mserver, dv, pm, reports, np, ml, 
   if ml == "TRUE":
     if ml_pm == "TRUE":
       pm_modlogs = True
+    else
+      pm_modlogs = False
     modlog.run(lemmy, user, instance, live, room, muser, mpw, mserver, pm_modlogs)
 
   if reports != "TRUE":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pythorhead==0.30.1
+pythorhead==0.31.0
 matrix-nio
 firebase-admin


### PR DESCRIPTION
Add monitoring of modlogs.
Currently only supports ModRemovePosts (see #6)

Note this is currently collecting modlogs from *subscribed* communities, not *moderated* communities.  This is due to a bug in Lemmy where asking for Moderated communities appears to return All.

Also adds a facility to PM the user when their post gets removed, with the reason.

The deployment is set to not collect modlogs (function not active)
Suggest to run this on the modbots, but we need to sub to the correct communities with them before enabling.
Suggest to enable MODLOG_PM only after it has run at least once, otherwise we risk PMing somebody with an old report.
