### PR TITLE
Add ModAddToCommunity, ModBanFromCommunity

### DIFF
--- a/modlog.py
+++ b/modlog.py
@@ -95,9 +95,9 @@ def added_to_community(lemmy, live, c, available_communities, processed_modlogs,
 
     if pm_modlogs is True:
       if 'display_name' in user['modded_person']:
-        msg_to = user['modded_person']['display_name']
+        msg_to = log['modded_person']['display_name']
       else:
-        msg_to = user['modded_person']['name']
+        msg_to = log['modded_person']['name']
 
     if live:
       processed.append(log['mod_add_community']['id']) # mark modlog as processed
@@ -137,9 +137,9 @@ def banned_from_community(lemmy, live, c, available_communities, processed_modlo
     print(f"{log['mod_ban_from_community']['id']} {msg}")
     if pm_modlogs is True:
       if 'display_name' in user['banned_person']:
-        msg_to = user['banned_person']['display_name']
+        msg_to = log['banned_person']['display_name']
       else:
-        msg_to = user['banned_person']['name']
+        msg_to = log['banned_person']['name']
 
     if live:
       processed.append(log['mod_ban_from_community']['id']) # mark modlog as processed

--- a/modlog.py
+++ b/modlog.py
@@ -236,7 +236,7 @@ def run(lemmy, l_user, l_inst, live, room, muser, mpw, mserver, pm_modlogs):
         available_communities['added_to_community'].append(c)
 
     # process removed comments
-    processed = removed_comments(lemmy, live, c, available_communities['banned_from_community'], processed_modlogs['banned_from_community'], room, muser, mpw, mserver, pm_modlogs)
+    processed = banned_from_community(lemmy, live, c, available_communities['banned_from_community'], processed_modlogs['banned_from_community'], room, muser, mpw, mserver, pm_modlogs)
 
     if live:
       processed_modlogs['banned_from_community'].extend(processed)

--- a/modlog.py
+++ b/modlog.py
@@ -88,7 +88,7 @@ def added_to_community(lemmy, live, c, available_communities, processed_modlogs,
     if log['mod_add_community']['id'] in processed_modlogs:
       break # stop processing if we've already seen a log as they are in descending order
     if log['mod_add_community']['removed'] is not False:
-      break # not interested in removed mods
+      continue # not interested in removed mods
 
     msg = f"\"{log['modded_person']['name']}\" has been added as a mod for \"{log['community']['name']}\" by \"{log['moderator']['name']}\""
     print(f"{log['mod_add_community']['id']} {msg}")
@@ -121,7 +121,7 @@ def banned_from_community(lemmy, live, c, available_communities, processed_modlo
     if log['mod_ban_from_community']['id'] in processed_modlogs:
       break # stop processing if we've already seen a log as they are in descending order
     if log['mod_ban_from_community']['banned'] is not True:
-      break # not interested in unbans
+      continue # not interested in unbans
 
     if "reason" in log['mod_ban_from_community']:
       reason = log['mod_ban_from_community']['reason']

--- a/modlog.py
+++ b/modlog.py
@@ -178,7 +178,7 @@ def run(lemmy, l_user, l_inst, live, room, muser, mpw, mserver, pm_modlogs):
 
     # process added mods
     # NB: Sending PMs for this action is disabled
-    processed = added_to_community(lemmy, live, c, available_communities['removed_comments'], processed_modlogs['removed_comments'], room, muser, mpw, mserver, False)
+    processed = added_to_community(lemmy, live, c, available_communities['added_to_community'], processed_modlogs['added_to_community'], room, muser, mpw, mserver, False)
 
     if live:
       processed_modlogs['added_to_community'].extend(processed)

--- a/modlog.py
+++ b/modlog.py
@@ -112,7 +112,7 @@ def added_to_community(lemmy, live, c, available_communities, processed_modlogs,
   return(processed)
 
 
-def banned_from_communiy(lemmy, live, c, available_communities, processed_modlogs, room, muser, mpw, mserver, pm_modlogs):
+def banned_from_community(lemmy, live, c, available_communities, processed_modlogs, room, muser, mpw, mserver, pm_modlogs):
   ml = lemmy.modlog.get(community_id=c,type_=ModlogActionType.ModBanFromCommunity,limit=4)
   processed = []
   ppid = 0

--- a/modlog.py
+++ b/modlog.py
@@ -87,6 +87,8 @@ def added_to_community(lemmy, live, c, available_communities, processed_modlogs,
   for log in ml['added_to_community']:
     if log['mod_add_community']['id'] in processed_modlogs:
       break # stop processing if we've already seen a log as they are in descending order
+    if log['mod_add_community']['removed'] is not False:
+      break # not interested in removed mods
 
     msg = f"\"{log['modded_person']['name']}\" has been added as a mod for \"{log['community']['name']}\" by \"{log['moderator']['name']}\""
     print(f"{log['mod_add_community']['id']} {msg}")

--- a/modlog.py
+++ b/modlog.py
@@ -22,7 +22,7 @@ def removed_posts(lemmy, live, c, available_communities, processed_modlogs, room
     if "reason" in log['mod_remove_post']:
       reason = log['mod_remove_post']['reason']
     else:
-      reason = "None given"
+      reason = "(not specified)"
     msg = f"\"{log['post']['name']}\" in \"{log['community']['name']}\" has been removed due to reason: {reason}"
     print(f"{log['mod_remove_post']['id']} {msg}")
 
@@ -57,7 +57,7 @@ def removed_comments(lemmy, live, c, available_communities, processed_modlogs, r
     if "reason" in log['mod_remove_comment']:
       reason = log['mod_remove_comment']['reason']
     else:
-      reason = "None given"
+      reason = "(not specified)"
     msg = f"\"{log['comment']['content']}\" under post \"{log['post']['name']}\" ({log['post']['ap_id']}) in \"{log['community']['name']}\" has been removed due to reason: {reason}"
     print(f"{log['mod_remove_comment']['id']} {msg}")
     if pm_modlogs is True:
@@ -94,11 +94,10 @@ def added_to_community(lemmy, live, c, available_communities, processed_modlogs,
     print(f"{log['mod_add_community']['id']} {msg}")
 
     if pm_modlogs is True:
-      user=lemmy.user.get(person_id=log['modded_person']['id']) # look up user
-      if 'display_name' in user['person_view']['person']:
-        msg_to = user['person_view']['person']['display_name']
+      if 'display_name' in user['modded_person']:
+        msg_to = user['modded_person']['display_name']
       else:
-        msg_to = user['person_view']['person']['name']
+        msg_to = user['modded_person']['name']
 
     if live:
       processed.append(log['mod_add_community']['id']) # mark modlog as processed
@@ -113,17 +112,61 @@ def added_to_community(lemmy, live, c, available_communities, processed_modlogs,
   return(processed)
 
 
+def banned_from_communiy(lemmy, live, c, available_communities, processed_modlogs, room, muser, mpw, mserver, pm_modlogs):
+  ml = lemmy.modlog.get(community_id=c,type_=ModlogActionType.ModBanFromCommunity,limit=4)
+  processed = []
+  ppid = 0
+
+  for log in ml['banned_from_community']:
+    if log['mod_ban_from_community']['id'] in processed_modlogs:
+      break # stop processing if we've already seen a log as they are in descending order
+    if log['mod_ban_from_community']['banned'] is not True:
+      break # not interested in unbans
+
+    if "reason" in log['mod_ban_from_community']:
+      reason = log['mod_ban_from_community']['reason']
+    else:
+      reason = "(not specified)"
+
+    if "expires" in log['mod_ban_from_community']: # suspect a permanent ban won't have an expiry date
+      expires = log['mod_ban_from_community']['expires']
+    else:
+      expires = "(not specified)"
+
+    msg = f"\"{log['banned_person']['name']}\" has been banned from \"{log['community']['name']}\" until {expires} due to reason: {reason}"
+    print(f"{log['mod_ban_from_community']['id']} {msg}")
+    if pm_modlogs is True:
+      if 'display_name' in user['banned_person']:
+        msg_to = user['banned_person']['display_name']
+      else:
+        msg_to = user['banned_person']['name']
+
+    if live:
+      processed.append(log['mod_ban_from_community']['id']) # mark modlog as processed
+      if c in available_communities: # only perform actions if we've seen the community before
+        # Post to Matrix
+        matrix.post(f'[modlog] {msg}', room, muser, mpw, mserver)
+        # Send PM to the poster
+        if pm_modlogs is True:
+          pm_msg = f"Dear {msg_to},\n\nYou have been banned from \"{log['community']['name']}\" until {expires} due to reason: {reason}"
+          lemmy.private_message.create(recipient_id=log['banned_person']['id'],content=pm_msg)
+
+  return(processed)
+
+
 
 def run(lemmy, l_user, l_inst, live, room, muser, mpw, mserver, pm_modlogs):
   processed_modlogs = {}
   processed_modlogs['removed_posts'] = []
   processed_modlogs['removed_comments'] = []
   processed_modlogs['added_to_community'] = []
+  processed_modlogs['banned_from_community'] = []
 
   available_communities = {}
   available_communities['removed_posts'] = []
   available_communities['removed_comments'] = []
   available_communities['added_to_community'] = []
+  available_communities['banned_from_community'] = []
 
   doc = f'{l_user}.{l_inst}'
   if live:
@@ -136,6 +179,8 @@ def run(lemmy, l_user, l_inst, live, room, muser, mpw, mserver, pm_modlogs):
     processed_modlogs['removed_comments'] = []
   if 'added_to_community' not in processed_modlogs:
     processed_modlogs['added_to_community'] = []
+  if 'banned_from_community' not in processed_modlogs:
+    processed_modlogs['banned_from_community'] = []
 
   if live:
     available_communities = firestore.get("modlog_communities", doc)
@@ -147,6 +192,8 @@ def run(lemmy, l_user, l_inst, live, room, muser, mpw, mserver, pm_modlogs):
     available_communities['removed_comments'] = []
   if 'added_to_community' not in available_communities:
     available_communities['added_to_community'] = []
+  if 'banned_from_community' not in available_communities:
+    available_communities['banned_from_community'] = []
 
   # get list of moderated commmunities
   commlist = []
@@ -187,6 +234,15 @@ def run(lemmy, l_user, l_inst, live, room, muser, mpw, mserver, pm_modlogs):
       if c not in available_communities['added_to_community']: # this is a new community, we need to add it so actions happen for new logs
         print(f'community with id {c} not seen previously for added_to_community, adding')
         available_communities['added_to_community'].append(c)
+
+    # process removed comments
+    processed = removed_comments(lemmy, live, c, available_communities['banned_from_community'], processed_modlogs['banned_from_community'], room, muser, mpw, mserver, pm_modlogs)
+
+    if live:
+      processed_modlogs['banned_from_community'].extend(processed)
+      if c not in available_communities['banned_from_community']: # this is a new community, we need to add it so actions happen for new logs
+        print(f'community with id {c} not seen previously for banned_from_community, adding')
+        available_communities['banned_from_community'].append(c)
 
 
 


### PR DESCRIPTION
Adds;
* ModAddToCommunity (notify if a new mod added to a community)
* ModBanFromCommunity (notify if a user is banned from a community)

Also changes the default reason to `(not specified)`

Avoids some user lookups when this information is already present in the modlog json.

Related to #6 